### PR TITLE
[NOISSUE] Fixed lint to files unders clustintime/*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+
+
+samples/

--- a/clustintime/Clustering.py
+++ b/clustintime/Clustering.py
@@ -10,7 +10,6 @@ import networkx as nx  # creation, manipulation and study of the structure, dyna
 import nibabel as nib
 import numpy as np
 import pandas as pd
-import Processing as proc
 import Visualization as vis
 from nilearn.input_data import NiftiMasker
 from sklearn.cluster import KMeans
@@ -87,7 +86,8 @@ def findCommunities(G):
 def K_Means(corr_map, indexes, nscans, n_clusters, task=[], TR=0.5, saving_dir=".", prefix=""):
     """
     K-Means uses a pre-stablished number of centroids and iterations defined by the user.
-    The algorithms places the centroids at random locations (real or imaginary, that represent the centre of the cluster) and then allocates each data point to the nearest cluster.
+    The algorithms places the centroids at random locations (real or imaginary, that represent the centre of
+    the cluster) and then allocates each data point to the nearest cluster.
     Afterwards, it will optimise the position of those centroids in the number of iterations defined.
 
     Parameters
@@ -144,8 +144,11 @@ def K_Means(corr_map, indexes, nscans, n_clusters, task=[], TR=0.5, saving_dir="
 
 def Info_Map(corr_map, indexes, thr, nscans, task=[], TR=0.5, saving_dir=".", prefix=""):
     """
-    InfoMap uses information theory to find communities. In particular, it employs the Huffman code to understand the flow of information within a graph. This code assigns a prefix to each node, then a prefix to each community.
-    When a random walker enters a network, the probability that it transitions between two nodes is given by its Markov transition matrix. Nonetheless, once the walker find itself inside a region, it is relatively improbable that it transitions onto another.
+    InfoMap uses information theory to find communities. In particular, it employs the Huffman code to understand
+    the flow of information within a graph. This code assigns a prefix to each node, then a prefix to each community.
+    When a random walker enters a network, the probability that it transitions between two nodes is given by its
+    Markov transition matrix. Nonetheless, once the walker find itself inside a region, it is relatively improbable
+    that it transitions onto another.
     InfoMap uses a random walker and applies the aforementioned theories to to find regions and nodes belonging to them.
 
 

--- a/clustintime/Processing.py
+++ b/clustintime/Processing.py
@@ -15,7 +15,8 @@ from scipy.signal import find_peaks
 
 def RSS_peaks(corr_map, near):
     """
-    Calculates the RSS of the correlation maps and returns the indexes of the time-points with the highest scores and the time-points nearby.
+    Calculates the RSS of the correlation maps and returns the indexes of the time-points with the highest
+    scores and the time-points nearby.
 
     Parameters
     ----------
@@ -49,10 +50,10 @@ def RSS_peaks(corr_map, near):
     new_peaks = new_peaks[new_peaks != 0]
     new_peaks = np.array(list(set(new_peaks)))
     plt.plot(RSS_1)
-    
-    filtered_plot = np.array([np.mean(RSS_1)]*len(RSS_1))
+
+    filtered_plot = np.array([np.mean(RSS_1)] * len(RSS_1))
     filtered_plot[new_peaks] = np.array(RSS_1)[new_peaks]
-    
+
     plt.plot(filtered_plot)
     plt.title("RSS of original data vs filtered RSS")
     plt.legend(["Original RSS"], "Filtered RSS")
@@ -121,7 +122,8 @@ def correlation_with_window(data, window_length):
                     (temp, data[timepoint + window_idx + 1, :])
                 )  # The data is concatenated for all the rows in the window
         else:
-            # The last rows will be concatenated (since there are less rows than the specified length once the loop finishes, you can exit it)
+            # The last rows will be concatenated (since there are less rows than the specified length once the
+            # loop finishes, you can exit it)
             for window_idx in range(window_length):
                 if (timepoint + window_idx + 1) < (data.shape[0]):
                     temp = np.concatenate((temp, data[timepoint + window_idx + 1, :]))
@@ -133,7 +135,9 @@ def correlation_with_window(data, window_length):
     return corr_map_window
 
 
-def preprocess(corr_map, analysis, data=None, window_size=1, near=1, thr=95, contrast=1, task=[], TR = 0.5):
+def preprocess(
+    corr_map, analysis, data=None, window_size=1, near=1, thr=95, contrast=1, task=[], TR=0.5
+):
     """
     Main workflow for the processing algorithms
 
@@ -169,7 +173,9 @@ def preprocess(corr_map, analysis, data=None, window_size=1, near=1, thr=95, con
     indexes = range(corr_map.shape[0])
     if analysis == "thr":
         aux, indexes = thr_index(corr_map, thr)
-        vis.plot_two_matrixes(corr_map, aux, "Original matrix", "Filtered matrix", task, contrast, TR)
+        vis.plot_two_matrixes(
+            corr_map, aux, "Original matrix", "Filtered matrix", task, contrast, TR
+        )
         corr_map, indexes = thr_index(corr_map, thr)
     elif analysis == "RSS":
         indexes = RSS_peaks(corr_map, near)
@@ -180,7 +186,7 @@ def preprocess(corr_map, analysis, data=None, window_size=1, near=1, thr=95, con
             "Filtered matrix",
             task,
             contrast,
-            TR
+            TR,
         )
         corr_map = pd.DataFrame(corr_map).loc[indexes, indexes]
     elif analysis == "double":
@@ -191,7 +197,7 @@ def preprocess(corr_map, analysis, data=None, window_size=1, near=1, thr=95, con
             "Double correlation matrix",
             task,
             contrast,
-            TR
+            TR,
         )
         corr_map = np.nan_to_num(np.corrcoef(corr_map))
     elif analysis == "window":
@@ -202,7 +208,7 @@ def preprocess(corr_map, analysis, data=None, window_size=1, near=1, thr=95, con
             f"Correlation with sliding window size {window_size} ",
             task,
             contrast,
-            TR
+            TR,
         )
         corr_map = correlation_with_window(data, window_size)
     return corr_map, indexes

--- a/clustintime/Visualization.py
+++ b/clustintime/Visualization.py
@@ -104,24 +104,20 @@ def plot_heatmap(labels, title, task=[], TR=0.5):
     heatmatrix = np.zeros([int(labels.max()), len(labels)])
     rownames = np.zeros([int(labels.max())]).astype(str)
     x = np.linspace(0, len(labels) * TR, len(labels)).astype(int)
-    
+
     for i in range(int(labels.max())):
         selected_labels = np.array([0] * len(labels))
         selected_labels[np.where(labels == i + 1)] = 1
         heatmatrix[i] = selected_labels
-        rownames[i] = f'Cluster {i+1}'
-    
-    heatmatrix = pd.DataFrame(heatmatrix,columns = x ,index = rownames)
+        rownames[i] = f"Cluster {i+1}"
+
+    heatmatrix = pd.DataFrame(heatmatrix, columns=x, index=rownames)
     colors = sns.color_palette("bright", len(task))
-    sns.heatmap(heatmatrix,  cmap = 'YlGnBu', xticklabels = 150)
-    plt.xlabel('Time in seconds', fontsize = 10)
-    
+    sns.heatmap(heatmatrix, cmap="YlGnBu", xticklabels=150)
+    plt.xlabel("Time in seconds", fontsize=10)
+
     for j in range(len(task)):
-        plt.vlines(task[j]/TR, 0, labels.max() ,linewidth=1.2, colors=colors[j])
-    
-    
-    
-        
+        plt.vlines(task[j] / TR, 0, labels.max(), linewidth=1.2, colors=colors[j])
 
 
 def show_table(labels, saving_dir, prefix):
@@ -146,7 +142,7 @@ def show_table(labels, saving_dir, prefix):
     table_result.to_csv(f"{saving_dir}/{prefix}_Results.csv")
 
 
-def plot_two_matrixes(map_1, map_2, title_1, title_2, task=[], contrast=1, TR = 0.5):
+def plot_two_matrixes(map_1, map_2, title_1, title_2, task=[], contrast=1, TR=0.5):
     """
     Graphical comparison between two correlation maps
 
@@ -180,8 +176,8 @@ def plot_two_matrixes(map_1, map_2, title_1, title_2, task=[], contrast=1, TR = 
     # Vertical lines to delimit the instant in which the event occurs
     limit = map_1.shape[0]
     for i in range(len(task)):
-        ax1.vlines(task[i]/TR, ymin=0, ymax=limit, linewidth=0.7)
-        ax1.hlines(task[i]/TR , xmin=0, xmax=limit, linewidth=0.7) # Same for horizontal
+        ax1.vlines(task[i] / TR, ymin=0, ymax=limit, linewidth=0.7)
+        ax1.hlines(task[i] / TR, xmin=0, xmax=limit, linewidth=0.7)  # Same for horizontal
     ax1.set_title(title_1)
     ax1.set_xlim([0, limit])
     ax1.set_ylim([limit, 0])
@@ -191,8 +187,8 @@ def plot_two_matrixes(map_1, map_2, title_1, title_2, task=[], contrast=1, TR = 
     im = ax2.imshow(map_2, aspect="auto", vmin=-contrast, vmax=contrast, cmap="RdBu_r")
     limit = map_2.shape[0]
     for i in range(len(task)):
-        ax2.vlines(task[i]/TR, ymin=0, ymax=limit, linewidth=0.7)
-        ax2.hlines(task[i]/TR, xmin=0, xmax=limit, linewidth=0.7)  # Same for horizontal
+        ax2.vlines(task[i] / TR, ymin=0, ymax=limit, linewidth=0.7)
+        ax2.hlines(task[i] / TR, xmin=0, xmax=limit, linewidth=0.7)  # Same for horizontal
     ax2.set_title(title_2)
     ax2.set_xlim([0, limit])
     ax2.set_ylim([limit, 0])

--- a/clustintime/clustintime.py
+++ b/clustintime/clustintime.py
@@ -59,7 +59,8 @@ def clustintime(
         Desired type of processing, the options are `None`, `double`, `thr`, `RSS`, `window`.
         The default is `None`.
     timings : bool, optional
-        Boolean that indicates whether the timings of the task are known or not. If `True`, a path to the timings must be specified in `timings_file`.
+        Boolean that indicates whether the timings of the task are known or not.
+        If `True`, a path to the timings must be specified in `timings_file`.
         The default is True.
     window_size : int, optional
         Window size for the `window` processing option.
@@ -110,7 +111,7 @@ def clustintime(
 
     print("Mask applied!")
     # Create data
-    if timings == True:
+    if timings:
         # Load timings
         # 1D files are a txt file with the times in which the events occur. They are divided by TR
         task = {}
@@ -124,17 +125,17 @@ def clustintime(
     nscans = corr_map.shape[0]
     indexes = range(corr_map.shape[0])
 
-    if processing != None:
+    if processing is not None:
         corr_map, indexes = proc.preprocess(
-            corr_map = corr_map,
-            analysis = processing,
-            data = data,
-            window_size = window_size,
-            near = near,
-            thr = thr,
-            contrast = contrast,
-            task = task,
-            TR = TR
+            corr_map=corr_map,
+            analysis=processing,
+            data=data,
+            window_size=window_size,
+            near=near,
+            thr=thr,
+            contrast=contrast,
+            task=task,
+            TR=TR,
         )
 
     if algorithm == "infomap":
@@ -164,6 +165,6 @@ def clustintime(
             prefix=prefix,
         )
 
-    if save_maps == True:
+    if save_maps:
         clus.generate_maps(labels, saving_dir, data_file, mask_file, prefix)
     vis.Dyn(corr_map, labels, output_file=f"{saving_dir}/dyneusr_{algorithm}.html")

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ tag_prefix =
 parentdir_prefix =
 
 [flake8]
-max-line-length = 99
+max-line-length = 120
 exclude=*build/
 ignore = E203,E402,W503
 per-file-ignores =


### PR DESCRIPTION
# Context
Having a consistent codestyle is key to lower develoment time.
One of the most extended python linters is [black](https://pypi.org/project/black/).

This PR does not change the project's preferred linter (flake8), but applies black to all files under `clustintime/*` to make flake8 pass.

# Changes
## Now
black claims all files under clustintime are lint-compliant.
flake8 does not complain of any violations.
```
*[fix_lint][~/code/cris/clustintime]$ black --check clustintime
All done! ✨ 🍰 ✨
4 files would be left unchanged.
*[fix_lint][~/code/cris/clustintime]$ flake8 clustintime
*[fix_lint][~/code/cris/clustintime]$ 
```

This PR also changes the max character per line setting in flake8 config to 120, more consistent with modern IDEs.

Even though PEP-8 [reccomends](https://peps.python.org/pep-0008/#maximum-line-length) 79 characters per line, it also reccomends to change that value depending on the needs of your project. 
In this case, given the amount and verbosity of comments, I'd argue that increasing this number to 120 makes sense. Happy to discuss :smile: 