### PR TITLE
[REFACTOR] Change input variable names for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Optional arguments are:
 5. thr: necessary argument if Processing takes the value of 'thr'
 6. contrast: contrast for the correlation maps
 7. dir_path: directory for the finger_tapping timings
-8. TR: TR of the data, only necessary in finger_tapping events
+8. repetition_time: Repetition Time (TR) of the data, only necessary in finger_tapping events
 9. Algorithm: the possible values are 'infomap' or 'KMeans' 
 10. thr_infomap: necessary argument if the selected algorithm is infomap
 11. n_clusters: necessary argument if the selected algorithm is KMeans

--- a/clustintime/Processing.py
+++ b/clustintime/Processing.py
@@ -178,7 +178,7 @@ def correlation_with_window(data, window_length):
     return corr_map_window
 
 
-def preprocess(corr_map, analysis, saving_dir = '.', prefix = "",near=1, thr=95, contrast=1, task=[], TR = 0.5):
+def preprocess(corr_map, analysis, saving_dir = '.', prefix = "",near=1, thr=95, contrast=1, task=[], repetition_time = 0.5):
     """
     Main workflow for the processing algorithms
 
@@ -200,8 +200,8 @@ def preprocess(corr_map, analysis, saving_dir = '.', prefix = "",near=1, thr=95,
         Range of values of the correlation maps. The default is 1.
     task : dictionary or list, optional
         Structure containing the timings when the task is performed. The default is [].
-    TR: float, optional
-        TR of the data. The default is 0.5
+    repetition_time: float, optional
+        Repetition time (TR) of the data. The default is 0.5
 
     Returns
     -------
@@ -215,7 +215,7 @@ def preprocess(corr_map, analysis, saving_dir = '.', prefix = "",near=1, thr=95,
     if analysis == "thr":
         aux = corr_map.copy()
         aux = thr_index(aux, thr)
-        vis.plot_two_matrixes(corr_map, aux, "Original matrix", "Filtered matrix", task = task, contrast = contrast, TR= TR,saving_dir = saving_dir, prefix = f'{prefix}_orig_thr_{thr}')
+        vis.plot_two_matrixes(corr_map, aux, "Original matrix", "Filtered matrix", task = task, contrast = contrast, repetition_time= repetition_time,saving_dir = saving_dir, prefix = f'{prefix}_orig_thr_{thr}')
         corr_map = thr_index(corr_map, thr)
     elif analysis == "RSS":
         indexes = RSS_peaks(corr_map, near)
@@ -226,7 +226,7 @@ def preprocess(corr_map, analysis, saving_dir = '.', prefix = "",near=1, thr=95,
             "Filtered matrix",
             task = task,
             contrast = contrast,
-            TR = TR,
+            repetition_time = repetition_time,
             saving_dir = saving_dir, 
             prefix = f'{prefix}_orig_RSS_{near}',
         )
@@ -239,7 +239,7 @@ def preprocess(corr_map, analysis, saving_dir = '.', prefix = "",near=1, thr=95,
             "Double correlation matrix",
             task = task,
             contrast = contrast,
-            TR = TR,
+            TR = repetition_time,
             saving_dir = saving_dir, 
             prefix = f'{prefix}_orig_double',
         )

--- a/clustintime/Visualization.py
+++ b/clustintime/Visualization.py
@@ -43,7 +43,7 @@ def display_table(data):
     display(HTML(html))
 
 
-def plot_labels(labels, title, task=[], TR=0.5):
+def plot_labels(labels, title, task=[], repetition_time=0.5):
     """
     Visualization of all the clusters found along time
 
@@ -55,8 +55,8 @@ def plot_labels(labels, title, task=[], TR=0.5):
         Title for the plot.
     task : dictionary or list, optional
         Structure containing the times when the task is performed. The default is [].
-    TR : float, optional
-        TR of the data. The default is 0.5.
+    repetition_time : float, optional
+        repetition_time of the data. The default is 0.5.
 
     Returns
     -------
@@ -67,7 +67,7 @@ def plot_labels(labels, title, task=[], TR=0.5):
     colors = sns.color_palette("bright", len(task))
 
     plt.figure(figsize=[32, 16])
-    plt.xlim([0, len(labels) * TR])
+    plt.xlim([0, len(labels) * repetition_time])
     plt.ylim([0, labels.max()])
     plt.xlabel("Time in seconds", fontsize=30)
     plt.ylabel("# Cluster", fontsize=30)
@@ -75,13 +75,13 @@ def plot_labels(labels, title, task=[], TR=0.5):
     for i in range(int(labels.max())):
         selected_labels = np.array([0] * len(labels))
         selected_labels[np.where(labels == i + 1)] = labels[np.where(labels == i + 1)]
-        plt.fill_between(np.linspace(0, len(labels) * TR, len(labels)), selected_labels)
+        plt.fill_between(np.linspace(0, len(labels) * repetition_time, len(labels)), selected_labels)
 
     for i in range(len(task)):
         plt.vlines(task[i], 0, labels.max(), linewidth=1.2, colors=colors[i])
 
 
-def plot_heatmap(labels, title ,saving_dir,prefix,task=[], TR=0.5):
+def plot_heatmap(labels, title ,saving_dir,prefix,task=[], repetition_time=0.5):
     """
     Visualization of the clusters separately
 
@@ -97,8 +97,8 @@ def plot_heatmap(labels, title ,saving_dir,prefix,task=[], TR=0.5):
         Prefix for the image
     task : dictionary or list, optional
         Structure containing the times when the task is performed. The default is [].
-    TR : float, optional
-        TR of the data. The default is 0.5.
+    repetition_time : float, optional
+        repetition_time of the data. The default is 0.5.
 
     Returns
     -------
@@ -108,7 +108,7 @@ def plot_heatmap(labels, title ,saving_dir,prefix,task=[], TR=0.5):
     plt.figure(figsize = [8,8])
     heatmatrix = np.zeros([int(labels.max()), len(labels)])
     rownames = np.zeros([int(labels.max())]).astype(str)
-    x = np.linspace(0, len(labels) * TR, len(labels)).astype(int)
+    x = np.linspace(0, len(labels) * repetition_time, len(labels)).astype(int)
     
     for i in range(int(labels.max())):
         selected_labels = np.array([0] * len(labels))
@@ -125,7 +125,7 @@ def plot_heatmap(labels, title ,saving_dir,prefix,task=[], TR=0.5):
     legends = np.zeros([len(task)]).astype(str)
     rectangles = [patches.Rectangle((0,0),1,1, facecolor = colors[0])]
     for j in range(len(task)):
-        plt.vlines(task[j]/TR, 0, labels.max() ,linewidth=1.2, colors=colors[j], alpha = 0.5)
+        plt.vlines(task[j]/repetition_time, 0, labels.max() ,linewidth=1.2, colors=colors[j], alpha = 0.5)
         legends[j] = f'task {j}'
         rectangles.append(patches.Rectangle((0,0),1,1, facecolor = colors[j+1]))
     plt.title(title)
@@ -160,7 +160,7 @@ def show_table(labels, saving_dir, prefix):
     table_result.to_csv(f"{saving_dir}/{prefix}_Results.csv")
 
 
-def plot_two_matrixes(map_1, map_2, title_1, title_2, saving_dir, prefix,task=[], contrast=1, TR = 0.5):
+def plot_two_matrixes(map_1, map_2, title_1, title_2, saving_dir, prefix,task=[], contrast=1, repetition_time = 0.5):
     """
     Graphical comparison between two correlation maps
 
@@ -178,8 +178,8 @@ def plot_two_matrixes(map_1, map_2, title_1, title_2, saving_dir, prefix,task=[]
         Structure containing the times when the task is performed. The default is [].
     contrast : int, optional
         Range of values of the correlation matrixes. The default is 1.
-    TR: float, optional
-        TR of the data. The default is 0.5
+    repetition_time: float, optional
+        repetition_time of the data. The default is 0.5
 
     Returns
     -------
@@ -194,8 +194,8 @@ def plot_two_matrixes(map_1, map_2, title_1, title_2, saving_dir, prefix,task=[]
     # Vertical lines to delimit the instant in which the event occurs
     limit = map_1.shape[0]
     for i in range(len(task)):
-        ax1.vlines(task[i]/TR, ymin=0, ymax=limit, linewidth=0.7)
-        ax1.hlines(task[i]/TR , xmin=0, xmax=limit, linewidth=0.7) # Same for horizontal
+        ax1.vlines(task[i]/repetition_time, ymin=0, ymax=limit, linewidth=0.7)
+        ax1.hlines(task[i]/repetition_time , xmin=0, xmax=limit, linewidth=0.7) # Same for horizontal
     ax1.set_title(title_1)
     ax1.set_xlim([0, limit])
     ax1.set_ylim([limit, 0])
@@ -205,8 +205,8 @@ def plot_two_matrixes(map_1, map_2, title_1, title_2, saving_dir, prefix,task=[]
     im = ax2.imshow(map_2, aspect="equal", vmin=-contrast, vmax=contrast, cmap="RdBu_r")
     limit = map_2.shape[0]
     for i in range(len(task)):
-        ax2.vlines(task[i]/TR, ymin=0, ymax=limit, linewidth=0.7)
-        ax2.hlines(task[i]/TR, xmin=0, xmax=limit, linewidth=0.7)  # Same for horizontal
+        ax2.vlines(task[i]/repetition_time, ymin=0, ymax=limit, linewidth=0.7)
+        ax2.hlines(task[i]/repetition_time, xmin=0, xmax=limit, linewidth=0.7)  # Same for horizontal
     ax2.set_title(title_2)
     ax2.set_xlim([0, limit])
     ax2.set_ylim([limit, 0])

--- a/clustintime/clustintime.py
+++ b/clustintime/clustintime.py
@@ -163,7 +163,7 @@ def clustintime(
             thr = thr,
             contrast = contrast,
             task = task,
-            TR = repetition_time
+            repetition_time = repetition_time
         )
 
     if algorithm == "infomap":
@@ -180,7 +180,7 @@ def clustintime(
                 )
 
         vis.plot_two_matrixes(
-            corr_map_2, corr_map, "Original correlation map", "Binary correlation map",task = task,  saving_dir = saving_dir, prefix = f'{prefix}_orig_binary',TR= repetition_time ,contrast = contrast
+            corr_map_2, corr_map, "Original correlation map", "Binary correlation map",task = task,  saving_dir = saving_dir, prefix = f'{prefix}_orig_binary',repetition_time= repetition_time ,contrast = contrast
         )
     elif algorithm == "KMeans":
         if consensus:
@@ -220,7 +220,7 @@ def clustintime(
                 nscans=nscans
                 )
         vis.plot_two_matrixes(
-            corr_map_2, corr_map, "Original correlation map", "Binary correlation map",task = task, saving_dir = saving_dir, prefix = f'{prefix}_orig_binary', TR= repetition_time ,contrast = contrast
+            corr_map_2, corr_map, "Original correlation map", "Binary correlation map",task = task, saving_dir = saving_dir, prefix = f'{prefix}_orig_binary', repetition_time= repetition_time ,contrast = contrast
         )
     elif algorithm == "Greedy":
         corr_map_2 = corr_map.copy()
@@ -235,10 +235,10 @@ def clustintime(
                 nscans=nscans
                 )
         vis.plot_two_matrixes(
-            corr_map_2, corr_map, "Original correlation map", "Binary correlation map",task = task,saving_dir = saving_dir, prefix = f'{prefix}_orig_binary',  TR= repetition_time ,contrast = contrast
+            corr_map_2, corr_map, "Original correlation map", "Binary correlation map",task = task,saving_dir = saving_dir, prefix = f'{prefix}_orig_binary',  repetition_time= repetition_time ,contrast = contrast
         )
 
-    vis.plot_heatmap(labels, title, task = task, TR = repetition_time,  saving_dir = saving_dir, prefix = prefix)
+    vis.plot_heatmap(labels, title, task = task, repetition_time = repetition_time,  saving_dir = saving_dir, prefix = prefix)
     vis.show_table(labels, saving_dir, prefix)
     if save_maps:
         clus.generate_maps(labels, saving_dir, data, masker, prefix)
@@ -253,7 +253,7 @@ def clustintime(
             difference = np.diff(all_time_points)
             select = find_peaks(difference)[0]
             fir_timepoints = np.insert(all_time_points[select+1],0, all_time_points[0])
-            vis.plot_heatmap(labels, f'FIR onsets for cluster {i+1}' ,f'{saving_dir}/fir',f'{prefix}_fir_{i+1}',task=[fir_timepoints*repetition_time], TR=repetition_time)
+            vis.plot_heatmap(labels, f'FIR onsets for cluster {i+1}' ,f'{saving_dir}/fir',f'{prefix}_fir_{i+1}',task=[fir_timepoints*repetition_time], repetition_time=repetition_time)
             np.savetxt(f'{saving_dir}/fir/{prefix}_FIR_Cluster_{i+1}.1D',fir_timepoints*repetition_time)
 
 def _main(argv = None):

--- a/clustintime/clustintime.py
+++ b/clustintime/clustintime.py
@@ -38,7 +38,7 @@ def clustintime(
     near=1,
     thr=95,
     contrast=1,
-    TR=0.5,
+    repetition_time=0.5,
     affinity = 'euclidean',
     linkage = 'ward',
     algorithm="infomap",
@@ -48,9 +48,9 @@ def clustintime(
     saving_dir=".",
     prefix="",
     seed=0,
-    Dyn = False,
+    generate_dyneusr_graph = False,
     fir = False,
-    Title = ""
+    title = ""
 ):
     """
     Run main workflow of clustintime.
@@ -89,8 +89,8 @@ def clustintime(
     contrast : float, optional
         Range of values for the correlation matrixes.
         The default is 1.
-    TR : float, optional
-        TR of the data.
+    repetition_time : float, optional
+        Repetition time of the data.
         The default is 0.5.
     algorithm : str, optional
         Desired clustering algorithm for the analysis, the options are `infomap` and `KMeans`.
@@ -109,9 +109,9 @@ def clustintime(
         The default is ".".
     prefix: str, optional
         Prefix for the saved outcomes
-    Dyn : bool, optional
+    generate_dyneusr_graph : bool, optional
         Generate a DyNeuSR graph. Default is `False`
-    Title: str, optional
+    title: str, optional
         Title for the graphs
 
     Returns
@@ -138,7 +138,7 @@ def clustintime(
     # Create data
     if timings_file != None:
         # Load timings
-        # 1D files are a txt file with the times in which the events occur. They are divided by TR
+        # 1D files are a txt file with the times in which the events occur. They are divided by the repetition_time. 
         task = {}
         if type(timings_file) == str:
             timings_file = [timings_file]
@@ -163,7 +163,7 @@ def clustintime(
             thr = thr,
             contrast = contrast,
             task = task,
-            TR = TR
+            TR = repetition_time
         )
 
     if algorithm == "infomap":
@@ -180,7 +180,7 @@ def clustintime(
                 )
 
         vis.plot_two_matrixes(
-            corr_map_2, corr_map, "Original correlation map", "Binary correlation map",task = task,  saving_dir = saving_dir, prefix = f'{prefix}_orig_binary',TR= TR ,contrast = contrast
+            corr_map_2, corr_map, "Original correlation map", "Binary correlation map",task = task,  saving_dir = saving_dir, prefix = f'{prefix}_orig_binary',TR= repetition_time ,contrast = contrast
         )
     elif algorithm == "KMeans":
         if consensus:
@@ -220,7 +220,7 @@ def clustintime(
                 nscans=nscans
                 )
         vis.plot_two_matrixes(
-            corr_map_2, corr_map, "Original correlation map", "Binary correlation map",task = task, saving_dir = saving_dir, prefix = f'{prefix}_orig_binary', TR= TR ,contrast = contrast
+            corr_map_2, corr_map, "Original correlation map", "Binary correlation map",task = task, saving_dir = saving_dir, prefix = f'{prefix}_orig_binary', TR= repetition_time ,contrast = contrast
         )
     elif algorithm == "Greedy":
         corr_map_2 = corr_map.copy()
@@ -235,15 +235,15 @@ def clustintime(
                 nscans=nscans
                 )
         vis.plot_two_matrixes(
-            corr_map_2, corr_map, "Original correlation map", "Binary correlation map",task = task,saving_dir = saving_dir, prefix = f'{prefix}_orig_binary',  TR= TR ,contrast = contrast
+            corr_map_2, corr_map, "Original correlation map", "Binary correlation map",task = task,saving_dir = saving_dir, prefix = f'{prefix}_orig_binary',  TR= repetition_time ,contrast = contrast
         )
 
-    vis.plot_heatmap(labels, Title, task = task, TR = TR,  saving_dir = saving_dir, prefix = prefix)
+    vis.plot_heatmap(labels, title, task = task, TR = repetition_time,  saving_dir = saving_dir, prefix = prefix)
     vis.show_table(labels, saving_dir, prefix)
     if save_maps:
         clus.generate_maps(labels, saving_dir, data, masker, prefix)
     
-    if Dyn:
+    if generate_dyneusr_graph:
         vis.Dyn(corr_map, labels, output_file=f"{saving_dir}/dyneusr_{prefix}.html")
     if fir:
         if os.path.exists(f'{saving_dir}/fir')==0:
@@ -253,8 +253,8 @@ def clustintime(
             difference = np.diff(all_time_points)
             select = find_peaks(difference)[0]
             fir_timepoints = np.insert(all_time_points[select+1],0, all_time_points[0])
-            vis.plot_heatmap(labels, f'FIR onsets for cluster {i+1}' ,f'{saving_dir}/fir',f'{prefix}_fir_{i+1}',task=[fir_timepoints*TR], TR=TR)
-            np.savetxt(f'{saving_dir}/fir/{prefix}_FIR_Cluster_{i+1}.1D',fir_timepoints*TR)
+            vis.plot_heatmap(labels, f'FIR onsets for cluster {i+1}' ,f'{saving_dir}/fir',f'{prefix}_fir_{i+1}',task=[fir_timepoints*repetition_time], TR=repetition_time)
+            np.savetxt(f'{saving_dir}/fir/{prefix}_FIR_Cluster_{i+1}.1D',fir_timepoints*repetition_time)
 
 def _main(argv = None):
     print(sys.argv)


### PR DESCRIPTION
# Context

The Clustintime CLI had three not-very-clear option names.
This PR renames those for clarity.
The renamed arguments are:
- `TR` -> `repetition_time`.
- `Dyn` -> `generate_dyneusr_graph`.
- `Title` -> `title` (for PEP8 reasons).
